### PR TITLE
Avoid committing user-specific preferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 
 .DS_Store
+
+preferences.json

--- a/preferences.example.json
+++ b/preferences.example.json
@@ -1,0 +1,1 @@
+{"consecutivo": 1, "directorio": "", "nomenclatura": "Etiqueta"}

--- a/preferences.json
+++ b/preferences.json
@@ -1,1 +1,0 @@
-{"consecutivo": 23, "directorio": "/Users/raulmb/Downloads/New Labels", "nomenclatura": "Etiqueta"}

--- a/utils/model_manager.py
+++ b/utils/model_manager.py
@@ -3,14 +3,19 @@ import json
 
 # Ruta donde se guardan las preferencias y el consecutivo
 PREFERENCES_FILE = 'preferences.json'
+DEFAULT_PREFERENCES_FILE = 'preferences.example.json'
 
 
 def cargar_datos():
     """
-    Carga las preferencias y el consecutivo desde un archivo JSON.
+    Carga las preferencias y el consecutivo desde un archivo JSON. Si el archivo
+    de usuario no existe, intenta cargar desde ``preferences.example.json``.
     """
     if os.path.exists(PREFERENCES_FILE):
         with open(PREFERENCES_FILE, 'r') as file:
+            return json.load(file)
+    elif os.path.exists(DEFAULT_PREFERENCES_FILE):
+        with open(DEFAULT_PREFERENCES_FILE, 'r') as file:
             return json.load(file)
     else:
         return {"consecutivo": 1, "directorio": "", "nomenclatura": "Etiqueta"}


### PR DESCRIPTION
## Summary
- remove `preferences.json` from version control
- ignore `preferences.json`
- provide a sanitized `preferences.example.json`
- load the example file when user preferences are missing

## Testing
- `python -m py_compile utils/model_manager.py`
- `python test.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_68403f4f3750832282a4bb9fa51ec4e4