### PR TITLE
Add personal lab license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,10 @@
-MIT License
+Personal Lab License - Rolphs
 
-Copyright (c) 2024 Rolphs
+Este repositorio es un entorno personal de desarrollo experimental. No está destinado a distribución pública como paquete de software completo.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+- El código, ideas, experimentos y prototipos aquí contenidos están en distintas etapas de desarrollo, prueba y documentación.
+- No se autoriza la redistribución, reutilización, modificación o explotación comercial de este repositorio en su conjunto sin autorización expresa del autor.
+- Los proyectos derivados que emergen de este laboratorio cuentan, en cada caso, con su propia licencia explícita según corresponda.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Copyright (c) Raúl Mercado Bustamante
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -64,5 +64,13 @@ El código aquí dentro está en distintas fases:
 
 ## Licencia
 
-Este repositorio no es un paquete público ni un producto terminado.  
-Cada proyecto derivado tiene su propia licencia específica.
+Personal Lab License - Rolphs
+
+Este repositorio es un entorno personal de desarrollo experimental. No está destinado a distribución pública como paquete de software completo.
+
+- El código, ideas, experimentos y prototipos aquí contenidos están en distintas etapas de desarrollo, prueba y documentación.
+- No se autoriza la redistribución, reutilización, modificación o explotación comercial de este repositorio en su conjunto sin autorización expresa del autor.
+- Los proyectos derivados que emergen de este laboratorio cuentan, en cada caso, con su propia licencia explícita según corresponda.
+
+Copyright (c) Raúl Mercado Bustamante
+


### PR DESCRIPTION
## Summary
- replace MIT license with Personal Lab License - Rolphs
- document the new license terms in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684c42775fe88322b6bf4fb2a6e69170