### PR TITLE
Add safety flags and git error handling

### DIFF
--- a/CODEX/README.md
+++ b/CODEX/README.md
@@ -27,7 +27,9 @@ Este espacio dentro de `Rolphs` organiza los distintos flujos de trabajo de inve
   Scripts utilitarios, funciones recurrentes, herramientas internas de apoyo.
 
 Al ejecutar `./experiments/new_experiment.sh` se crea un nuevo experimento y se
-realiza un commit y push automáticamente.
+realiza un commit y push automáticamente. El script ahora usa `set -euo
+pipefail` para detenerse ante cualquier error y muestra mensajes de ayuda si los
+comandos de Git fallan (por ejemplo, cuando no hay un remoto configurado).
 
 ---
 

--- a/CODEX/experiments/new_experiment.sh
+++ b/CODEX/experiments/new_experiment.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Ir al directorio actual del script
 cd "$(dirname "$0")"
@@ -59,5 +60,17 @@ echo "Experimento creado en: $dir"
 # Volver al directorio de experimentos y registrar el nuevo commit
 cd ..
 git add "$dir"
-git commit -m "Nuevo experimento inicializado: $dir"
-git push
+if ! git commit -m "Nuevo experimento inicializado: $dir"; then
+  echo "Error: Falló el commit en Git." >&2
+  exit 1
+fi
+
+if git remote > /dev/null 2>&1; then
+  if ! git push; then
+    echo "Error: Falló el push. Verifique la configuración del remoto." >&2
+    exit 1
+  fi
+else
+  echo "Error: No hay remoto configurado. No se pudo hacer push." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- enhance `CODEX/experiments/new_experiment.sh` with `set -euo pipefail`
- provide helpful errors when git commands fail
- document new behaviour in `CODEX/README.md`

## Testing
- `test -f README.md`
- `flake8 .`

------
https://chatgpt.com/codex/tasks/task_b_684c4b5a42f0832283d6338f18d0964f