### PR TITLE
Add BATS tests for new_experiment.sh

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,13 +18,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8
-      - name: Install shellcheck
+      - name: Install shellcheck and BATS
         run: |
           sudo apt-get update
-          sudo apt-get install -y shellcheck
+          sudo apt-get install -y shellcheck bats bats-assert bats-support bats-file
       - name: Lint with flake8
         if: ${{ hashFiles('**/*.py') != '' }}
         run: flake8 .
       - name: Lint shell scripts with shellcheck
         if: ${{ hashFiles('**/*.sh') != '' }}
         run: shellcheck $(git ls-files '*.sh')
+      - name: Run BATS tests
+        if: ${{ hashFiles('CODEX/experiments/tests/**/*.bats') != '' }}
+        run: bats CODEX/experiments/tests

--- a/CODEX/experiments/tests/new_experiment.bats
+++ b/CODEX/experiments/tests/new_experiment.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+load '/usr/lib/bats/bats-support/load'
+load '/usr/lib/bats/bats-assert/load'
+
+setup() {
+  TMP_REPO="$(mktemp -d)"
+  mkdir -p "$TMP_REPO/CODEX/experiments"
+  cp "$BATS_TEST_DIRNAME/../new_experiment.sh" "$TMP_REPO/CODEX/experiments/"
+  cd "$TMP_REPO/CODEX/experiments"
+  mkdir exp000_base
+  > exp000_base/README.md
+  > exp000_base/notes.md
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  git add exp000_base
+  git commit -m "init" >/dev/null
+}
+
+teardown() {
+  rm -rf "$TMP_REPO"
+}
+
+@test "creación del directorio numerado y archivos" {
+  run bash new_experiment.sh --no-push <<< "Prueba"
+  assert_success
+  assert_output --partial "exp001_prueba"
+  [ -d exp001_prueba ]
+  [ -f exp001_prueba/README.md ]
+  [ -f exp001_prueba/notes.md ]
+}
+
+@test "falla sin --no-push cuando no hay remoto" {
+  run bash new_experiment.sh <<< "Push"
+  assert_failure
+  assert_output --partial "Error: Falló el push"
+}


### PR DESCRIPTION
## Summary
- add BATS tests for the experiment creation script
- update CI workflow to install BATS and run tests

## Testing
- `flake8 .`
- `shellcheck $(git ls-files '*.sh')`
- `bats CODEX/experiments/tests`


------
https://chatgpt.com/codex/tasks/task_b_684c5d06685083229811fd0231ee40dd