### PR TITLE
Force JavaScript Actions to Node 24 in CI workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
       - name: Ensure README exists


### PR DESCRIPTION
## Descripción

Actualizar el workflow de CI para forzar el uso de Node 24 en las acciones de JavaScript, asegurando compatibilidad con versiones más recientes del runtime.

## Cambios realizados

- Agregada variable de entorno `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` al job `verify` en el workflow de GitHub Actions

## Pasos de prueba

1. Verificar que el workflow de CI se ejecuta correctamente en la rama
2. Confirmar que las acciones de JavaScript utilizan Node 24 sin errores de compatibilidad

https://claude.ai/code/session_01UgjJQ7WQQAvw9QC8XfcsaY