### PR TITLE
fix: Node.js 24 para Actions y shellcheck en new_experiment.sh

### DIFF
--- a/CODEX/experiments/new_experiment.sh
+++ b/CODEX/experiments/new_experiment.sh
@@ -20,7 +20,7 @@ done
 cd "$(dirname "$0")"
 
 # Buscar el último número de experimento
-last_num=$(ls -d exp* 2>/dev/null | sort | tail -n 1 | grep -o '[0-9]\+' | head -n 1)
+last_num=$(find . -maxdepth 1 -type d -name 'exp[0-9]*' | sort | tail -n 1 | grep -oE '[0-9]+' | head -n 1 || true)
 if [ -z "$last_num" ]; then
   next_num=1
 else
@@ -28,10 +28,10 @@ else
 fi
 
 # Formatear número a 3 dígitos
-exp_num=$(printf "%03d" $next_num)
+exp_num=$(printf "%03d" "$next_num")
 
 # Pedir nombre del experimento
-read -p "Nombre del experimento: " exp_name
+read -rp "Nombre del experimento: " exp_name
 
 # Limpiar nombre (espacios -> guiones bajos)
 clean_name=$(echo "$exp_name" | tr '[:upper:]' '[:lower:]' | sed 's/ /_/g')


### PR DESCRIPTION
## Resumen
- Agrega `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` al job `verify` para eliminar la advertencia de deprecación de Node.js 20 en `actions/checkout@v4`
- Corrige tres advertencias de shellcheck en `CODEX/experiments/new_experiment.sh` que causaban que el CI fallara con exit code 1

## Cambios

### CI (`.github/workflows/python-package.yml`)
- Opt-in a Node.js 24 antes de la migración forzada del 2 de junio de 2026

### Shell script (`CODEX/experiments/new_experiment.sh`)
- **SC2012**: reemplaza `ls -d exp*` con `find` para listar directorios
- **SC2086**: agrega comillas a `$next_num` en `printf`
- **SC2162**: agrega `-r` a `read` para no mutilar backslashes

## Plan de pruebas
- [ ] El job `verify` pasa sin advertencia de Node.js
- [ ] El paso `shellcheck` pasa sin errores
- [ ] Los tests BATS siguen pasando

https://claude.ai/code/session_01UgjJQ7WQQAvw9QC8XfcsaY