### PR TITLE
fix: corregir test BATS para bats-core 1.10 (Ubuntu 24.04)

### DIFF
--- a/CODEX/experiments/tests/new_experiment.bats
+++ b/CODEX/experiments/tests/new_experiment.bats
@@ -32,7 +32,7 @@ teardown() {
 }
 
 @test "falla sin --no-push cuando no hay remoto" {
-  run bash new_experiment.sh <<< "Push"
+  run bash -c 'bash new_experiment.sh <<< "Push" 2>&1'
   assert_failure
   assert_output --partial "Error: Falló el push"
 }


### PR DESCRIPTION
## Problema

El CI falla con exit code 1 incluso después de los fixes de shellcheck.

El test BATS `"falla sin --no-push cuando no hay remoto"` espera encontrar el mensaje `"Error: Falló el push"` en `$output`, pero ese mensaje lo imprime el script en **stderr** (`>&2`).

En **bats-core < 1.5** (Ubuntu 22.04, bats 1.2.1), `run` capturaba stdout y stderr combinados en `$output`. En **bats-core ≥ 1.5** (Ubuntu 24.04, bats 1.10.0, que es lo que usa `ubuntu-latest` hoy), stderr se separa y **no** aparece en `$output` por defecto. Resultado: `assert_output --partial "Error: Falló el push"` siempre falla.

## Fix

```diff
-  run bash new_experiment.sh <<< "Push"
+  run bash -c 'bash new_experiment.sh <<< "Push" 2>&1'
```

Al redirigir stderr a stdout dentro del subshell, `run` captura ambos en `$output`, compatiblemente con todas las versiones de bats.

## Plan de pruebas
- [ ] El job `verify` pasa sin errores
- [ ] Ambos tests BATS pasan

https://claude.ai/code/session_01UgjJQ7WQQAvw9QC8XfcsaY